### PR TITLE
Adjust fqdn regex to allow non-alphanumeric characters

### DIFF
--- a/backend/path_cert.go
+++ b/backend/path_cert.go
@@ -33,7 +33,7 @@ func pathCerts(b *backend) []*framework.Path {
 			Pattern: "certs/dns-01/" +
 				framework.GenericNameRegex("account") + "/" +
 				framework.GenericNameRegex("provider") + "/" +
-				framework.GenericNameRegex("fqdn"),
+				`(?P<fqdn>[^/]+)`,
 			Fields: map[string]*framework.FieldSchema{
 				"account": {
 					Type:        framework.TypeString,


### PR DESCRIPTION
The previous framework.GenericNameRegex only allows alphanumeric characters, which prevents wildcard domain paths from matching

Fixes #7